### PR TITLE
Adicionando Dagger Hilt ao projeto

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
     implementation(Dependencies.AndroidLifecycle.runtimeKtx)
     implementation(Dependencies.AndroidLifecycle.runtimeKtx)
     implementation(Dependencies.DependencyInjection.daggerHilt)
-    implementation(Dependencies.CodeGeneration.kapt)
+    kapt(Dependencies.DependencyInjection.daggerHiltCompiler)
     testImplementation(Dependencies.Tests.jUnit)
     androidTestImplementation(Dependencies.Tests.androidxExtjUnit)
     androidTestImplementation(Dependencies.Tests.espresso)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     id(DependencyPlugins.androidApplication)
     id(DependencyPlugins.kotlinAndroid)
     id(DependencyPlugins.kotlinAndroidExtensions)
+    id(DependencyPlugins.kotlinKapt)
+    id(DependencyPlugins.daggerHilt)
 }
 
 android {
@@ -64,6 +66,8 @@ dependencies {
     implementation(Dependencies.AndroidLifecycle.viewModelCompose)
     implementation(Dependencies.AndroidLifecycle.runtimeKtx)
     implementation(Dependencies.AndroidLifecycle.runtimeKtx)
+    implementation(Dependencies.DependencyInjection.daggerHilt)
+    implementation(Dependencies.CodeGeneration.kapt)
     testImplementation(Dependencies.Tests.jUnit)
     androidTestImplementation(Dependencies.Tests.androidxExtjUnit)
     androidTestImplementation(Dependencies.Tests.espresso)

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/Libs.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/Libs.kt
@@ -1,5 +1,0 @@
-package com.github.felipecastilhos.pokedexandroid
-
-object Libs {
-    const val composeVersion = "1.0.1"
-}

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/PokedexApplication.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/PokedexApplication.kt
@@ -1,0 +1,7 @@
+package com.github.felipecastilhos.pokedexandroid
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class PokedexApplication : Application()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ buildscript {
     dependencies {
         classpath(ClassPathDependencies.buildGradle)
         classpath(ClassPathDependencies.kotlinGradlePlugin)
+        classpath(ClassPathDependencies.hiltGradlePlugin)
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/buildSrc/src/main/java/BuildConfigVersions.kt
+++ b/buildSrc/src/main/java/BuildConfigVersions.kt
@@ -3,5 +3,5 @@ object BuildConfigVersions {
     const val minSdk = 23
     const val targetSdk = 31
     const val versionCode = 1
-    const val versionName = "1.0"
+    const val versionName = "0.0.2"
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -14,11 +14,21 @@ object DependencyVersions {
 
     const val buildGradle = "7.0.3"
     const val kotlinGradlePlugin = "1.5.21"
+    const val daggerHilt = "2.28-alpha"
+    const val kapt = "2.28-alpha"
 }
 
 sealed class Dependencies {
     object Core {
         const val androidxCore = "androidx.core:core-ktx:${DependencyVersions.androidxCore}"
+    }
+
+    object CodeGeneration {
+        const val kapt = "com.google.dagger:hilt-android-compiler:${DependencyVersions.kapt}}"
+    }
+
+    object DependencyInjection {
+        const val daggerHilt = "com.google.dagger:hilt-android:${DependencyVersions.daggerHilt}"
     }
 
     object Compose {
@@ -60,9 +70,12 @@ object DependencyPlugins {
     const val androidApplication = "com.android.application"
     const val kotlinAndroid = "kotlin-android"
     const val kotlinAndroidExtensions = "kotlin-android-extensions"
+    const val kotlinKapt = "kotlin-kapt"
+    const val daggerHilt = "dagger.hilt.android.plugin"
 }
 
 object ClassPathDependencies {
     const val buildGradle = "com.android.tools.build:gradle:${DependencyVersions.buildGradle}"
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${DependencyVersions.kotlinGradlePlugin}"
+    const val hiltGradlePlugin = "com.google.dagger:hilt-android-gradle-plugin:${DependencyVersions.daggerHilt}"
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,11 +11,10 @@ object DependencyVersions {
     const val androidxEspresso = "3.4.0"
     const val androidxComposeJunit = "1.0.5"
     const val kotlinCompilerExtension = "1.0.1"
+    const val daggerHilt = "2.37"
 
     const val buildGradle = "7.0.3"
     const val kotlinGradlePlugin = "1.5.21"
-    const val daggerHilt = "2.28-alpha"
-    const val kapt = "2.28-alpha"
 }
 
 sealed class Dependencies {
@@ -23,12 +22,9 @@ sealed class Dependencies {
         const val androidxCore = "androidx.core:core-ktx:${DependencyVersions.androidxCore}"
     }
 
-    object CodeGeneration {
-        const val kapt = "com.google.dagger:hilt-android-compiler:${DependencyVersions.kapt}}"
-    }
-
     object DependencyInjection {
         const val daggerHilt = "com.google.dagger:hilt-android:${DependencyVersions.daggerHilt}"
+        const val daggerHiltCompiler = "com.google.dagger:hilt-android-compiler:${DependencyVersions.daggerHilt}"
     }
 
     object Compose {


### PR DESCRIPTION
Esse PR adiciona e faz a configuração da biblioteca [Dagger Hilt](https://developer.android.com/training/dependency-injection/hilt-android?hl=pt-br) ao projeto. Para que seja possível fazer injeção de dependência no futuro.