### PR TITLE
Usando extensions para adicionar dependencias no gradle

### DIFF
--- a/buildSrc/src/main/java/DependencyHandlerExtensions.kt
+++ b/buildSrc/src/main/java/DependencyHandlerExtensions.kt
@@ -4,72 +4,92 @@ import org.gradle.kotlin.dsl.DependencyHandlerScope
  * Add AndroidX dependencies
  */
 fun DependencyHandlerScope.jetpackUtilLibraries() {
-    "implementation"(Dependencies.Core.androidxCore)
+    implementation(Dependencies.Core.androidxCore)
 }
 
 /**
  * Add AndroidX dependencies
  */
 fun DependencyHandlerScope.jetpackKotlinExtensionsLibraries() {
-    "implementation"("androidx.core:core-ktx:${DependencyVersions.androidxCore}")
+    implementation("androidx.core:core-ktx:${DependencyVersions.androidxCore}")
 }
 
 /**
  * Add JapackUi dependencies
  */
 fun DependencyHandlerScope.jetpackUiCommonsLibraries() {
-    "implementation"(Dependencies.JetpackUi.appCompat)
-    "implementation"(Dependencies.JetpackUi.material)
+    implementation(Dependencies.JetpackUi.appCompat)
+    implementation(Dependencies.JetpackUi.material)
 }
 
 /**
  * Add Japackcompose dependencies
  */
 fun DependencyHandlerScope.jetpackComposeLibraries() {
-    "implementation"(Dependencies.JetpackCompose.ui)
-    "implementation"(Dependencies.JetpackCompose.material)
-    "implementation"(Dependencies.JetpackCompose.uiToolingPreview)
-    "implementation"(Dependencies.JetpackCompose.activityCompose)
-    "implementation"(Dependencies.AndroidLifecycle.viewModelCompose)
-    "debugImplementation"(Dependencies.JetpackCompose.composeUiTooling)
+    implementation(Dependencies.JetpackCompose.ui)
+    implementation(Dependencies.JetpackCompose.material)
+    implementation(Dependencies.JetpackCompose.uiToolingPreview)
+    implementation(Dependencies.JetpackCompose.activityCompose)
+    implementation(Dependencies.AndroidLifecycle.viewModelCompose)
+    debugImplementation(Dependencies.JetpackCompose.composeUiTooling)
 }
 
 /**
  * Add Jetpack Compose Android lifecycle dependencies to handle better lifecycle changes
  */
 fun DependencyHandlerScope.jetpackAndroidLifecycleLibraries() {
-    "implementation"(Dependencies.AndroidLifecycle.runtimeKtx)
-    "implementation"(Dependencies.AndroidLifecycle.viewModelCompose)
+    implementation(Dependencies.AndroidLifecycle.runtimeKtx)
+    implementation(Dependencies.AndroidLifecycle.viewModelCompose)
 }
 
 /**
  * Add Dagger-Hilt dependencies for dependency injection
  */
 fun DependencyHandlerScope.daggerHiltLibraries() {
-    "implementation"(Dependencies.DependencyInjection.daggerHilt)
-    "kapt"(Dependencies.DependencyInjection.daggerHiltCompiler)
+    implementation(Dependencies.DependencyInjection.daggerHilt)
+    kapt(Dependencies.DependencyInjection.daggerHiltCompiler)
 }
 
 /**
  * Add Apollo Android client dependencies to manage both local and remote data with GraphQL.
  */
 fun DependencyHandlerScope.apolloClientLibraries() {
-    "implementation"(Dependencies.Network.apolloRuntime)
-    "implementation"(Dependencies.Network.apolloCoroutines)
+    implementation(Dependencies.Network.apolloRuntime)
+    implementation(Dependencies.Network.apolloCoroutines)
 }
 
 /**
  * Add unit tests dependencies.
  */
 fun DependencyHandlerScope.unitTestsLibraries() {
-    "testImplementation"(Dependencies.Tests.jUnit)
+    testImplementation(Dependencies.Tests.jUnit)
 }
 
 /**
  * Add unit tests dependencies.
  */
 fun DependencyHandlerScope.instrumentationTestsLibraries() {
-    "androidTestImplementation"(Dependencies.Tests.androidxExtjUnit)
-    "androidTestImplementation"(Dependencies.Tests.espresso)
-    "androidTestImplementation"(Dependencies.Tests.composejUnit)
+    androidTestImplementation(Dependencies.Tests.androidxExtjUnit)
+    androidTestImplementation(Dependencies.Tests.espresso)
+    androidTestImplementation(Dependencies.Tests.composejUnit)
+}
+
+fun DependencyHandlerScope.implementation(dependencyNotation: String) {
+    "implementation"(dependencyNotation)
+}
+
+fun DependencyHandlerScope.testImplementation(dependencyNotation: String) {
+    "testImplementation"(dependencyNotation)
+}
+
+fun DependencyHandlerScope.androidTestImplementation(dependencyNotation: String) {
+    "androidTestImplementation"(dependencyNotation)
+}
+
+fun DependencyHandlerScope.kapt(dependencyNotation: String) {
+    "kapt"(dependencyNotation)
+}
+
+fun DependencyHandlerScope.debugImplementation(dependencyNotation: String) {
+    "debugImplementation"(dependencyNotation)
 }


### PR DESCRIPTION
Como o opeador da DSL do kotlin é construido em cima de Strings, criei as extensions para reaproveitar mais e garantir que não haja erros por typo nas configurações. Que só seriam avisadas em tempo de build