### PR TITLE
Adiciona framework de log ao projeto

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,9 @@ dependencies {
     // Add networking libraries
     apolloClientLibraries()
 
+    // Add log libraries
+    logLibraries()
+
     // Add Tests
     unitTestsLibraries()
     instrumentationTestsLibraries()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.github.felipecastilhos.pokedexandroid">
 
     <application
+        android:name=".PokedexApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/PokedexApplication.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/PokedexApplication.kt
@@ -1,7 +1,20 @@
 package com.github.felipecastilhos.pokedexandroid
 
 import android.app.Application
+import com.github.felipecastilhos.pokedexandroid.logs.LogHandler
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class PokedexApplication : Application()
+class PokedexApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        dependenciesInitialize()
+    }
+
+    /**
+     * Inits all projects dependencies.
+     */
+    private fun dependenciesInitialize() {
+        LogHandler.init()
+    }
+}

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/logs/LogHandler.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/logs/LogHandler.kt
@@ -7,9 +7,9 @@ import timber.log.Timber
  * An wrapper to handle logs in the project
  */
 object LogHandler {
-    fun init() {
+    fun init(tree: Timber.Tree = Timber.DebugTree()) {
         if (BuildConfig.DEBUG) {
-            Timber.plant(Timber.DebugTree())
+            Timber.plant(tree)
         }
     }
 

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/logs/LogHandler.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/logs/LogHandler.kt
@@ -1,0 +1,36 @@
+package com.github.felipecastilhos.pokedexandroid.logs
+
+import com.github.felipecastilhos.pokedexandroid.BuildConfig
+import timber.log.Timber
+
+/**
+ * An wrapper to handle logs in the project
+ */
+object LogHandler {
+    fun init() {
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+    }
+
+    /** Log a debug exception and a message with optional format args. */
+    fun d(message: String, throwable: Throwable? = null) {
+        Timber.d(throwable, message)
+    }
+
+    /** Log a warning exception and a message with optional format args. */
+    fun w(message: String, throwable: Throwable? = null) {
+        Timber.w(throwable, message)
+    }
+
+    /** Log an info exception. */
+    fun i(message: String, throwable: Throwable? = null) {
+        Timber.i(throwable, message)
+    }
+
+    /** Log an error exception and a message with optional format args. */
+    fun e(throwable: Throwable?, message: String? = null) {
+        Timber.e(throwable, message)
+    }
+}
+

--- a/app/src/test/java/com/github/felipecastilhos/pokedexandroid/LogHandlerTest.kt
+++ b/app/src/test/java/com/github/felipecastilhos/pokedexandroid/LogHandlerTest.kt
@@ -1,0 +1,102 @@
+package com.github.felipecastilhos.pokedexandroid
+
+import com.github.felipecastilhos.pokedexandroid.logs.LogHandler
+import org.junit.Assert
+import org.junit.Test
+import timber.log.Timber
+
+class LogHandlerTest {
+    lateinit var testTree: TestTree
+
+    @Test
+    fun `given a log message is debug then should be logged as debug`() {
+        initLogHandler()
+        LogHandler.d(logMessage)
+        val lastLoggedEvent = testTree.logs.last()
+
+        Assert.assertEquals(logMessage, lastLoggedEvent.message)
+        Assert.assertEquals(Priorities.DEBUG.priorityLevel, lastLoggedEvent.priority)
+    }
+
+    @Test
+    fun `given a log message is warning then should be logged as warning`() {
+        initLogHandler()
+        LogHandler.w(logMessage)
+        val lastLoggedEvent = testTree.logs.last()
+
+        Assert.assertEquals(logMessage, lastLoggedEvent.message)
+        Assert.assertEquals(Priorities.WARNING.priorityLevel, lastLoggedEvent.priority)
+    }
+
+    @Test
+    fun `given a log message is error then should be logged as error`() {
+        initLogHandler()
+        LogHandler.e(throwable = null, message = logMessage)
+        val lastLoggedEvent = testTree.logs.last()
+
+        Assert.assertEquals(logMessage, lastLoggedEvent.message)
+        Assert.assertEquals(Priorities.ERROR.priorityLevel, lastLoggedEvent.priority)
+    }
+
+    @Test
+    fun `given a log throwable then should be logged as error`() {
+        initLogHandler()
+        val throwable = NullPointerException()
+        LogHandler.e(throwable = throwable)
+        val lastLoggedEvent = testTree.logs.last()
+
+        Assert.assertEquals(throwable, lastLoggedEvent.t)
+        Assert.assertEquals(Priorities.ERROR.priorityLevel, lastLoggedEvent.priority)
+    }
+
+    @Test
+    fun `given a log message is info then should be logged as info`() {
+        initLogHandler()
+        LogHandler.i(throwable = null, message = logMessage)
+        val lastLoggedEvent = testTree.logs.last()
+
+        Assert.assertEquals(logMessage, lastLoggedEvent.message)
+        Assert.assertEquals(Priorities.INFO.priorityLevel, lastLoggedEvent.priority)
+    }
+
+    private fun initLogHandler() {
+        testTree = TestTree()
+        LogHandler.init(testTree)
+    }
+
+    companion object {
+        const val logMessage = "This is a simple log message"
+
+        /**
+         * Enum containing all log priority levels
+         */
+        enum class Priorities(val priorityLevel: Int) {
+            DEBUG(3),
+            INFO(4),
+            WARNING(5),
+            ERROR(6)
+        }
+    }
+}
+
+/**
+ * This class is used to mock timber tree for test purposes
+ */
+class TestTree : Timber.Tree() {
+    /**
+     * Simulates the console log history stack
+     */
+    val logs = mutableListOf<Log>()
+
+    /**
+     * Add a message to the internal history stacktrace stack
+     */
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        logs.add(Log(priority, tag, message, t))
+    }
+
+    /**
+     * Modeling a log message to add into the history stacktrace stack
+     */
+    data class Log(val priority: Int, val tag: String?, val message: String, val t: Throwable?)
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -16,6 +16,7 @@ object DependencyVersions {
     const val buildGradle = "7.0.3"
     const val kotlinGradlePlugin = "1.5.21"
     const val apolloVersion = "2.5.11"
+    const val timber = "5.0.1"
 }
 
 sealed class Dependencies {
@@ -65,6 +66,10 @@ sealed class Dependencies {
     object Network {
         const val apolloRuntime = "com.apollographql.apollo:apollo-runtime:${DependencyVersions.apolloVersion}"
         const val apolloCoroutines = "com.apollographql.apollo:apollo-coroutines-support:${DependencyVersions.apolloVersion}"
+    }
+
+    object Log {
+        const val timber = "com.jakewharton.timber:timber:${DependencyVersions.timber}"
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -26,7 +26,8 @@ sealed class Dependencies {
 
     object DependencyInjection {
         const val daggerHilt = "com.google.dagger:hilt-android:${DependencyVersions.daggerHilt}"
-        const val daggerHiltCompiler = "com.google.dagger:hilt-android-compiler:${DependencyVersions.daggerHilt}"
+        const val daggerHiltCompiler =
+            "com.google.dagger:hilt-android-compiler:${DependencyVersions.daggerHilt}"
     }
 
     object AndroidLifecycle {
@@ -64,8 +65,10 @@ sealed class Dependencies {
     }
 
     object Network {
-        const val apolloRuntime = "com.apollographql.apollo:apollo-runtime:${DependencyVersions.apolloVersion}"
-        const val apolloCoroutines = "com.apollographql.apollo:apollo-coroutines-support:${DependencyVersions.apolloVersion}"
+        const val apolloRuntime =
+            "com.apollographql.apollo:apollo-runtime:${DependencyVersions.apolloVersion}"
+        const val apolloCoroutines =
+            "com.apollographql.apollo:apollo-coroutines-support:${DependencyVersions.apolloVersion}"
     }
 
     object Log {
@@ -84,6 +87,8 @@ object ModulePlugins {
 
 object GradlePlugins {
     const val buildGradle = "com.android.tools.build:gradle:${DependencyVersions.buildGradle}"
-    const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${DependencyVersions.kotlinGradlePlugin}"
-    const val hiltGradlePlugin = "com.google.dagger:hilt-android-gradle-plugin:${DependencyVersions.daggerHilt}"
+    const val kotlinGradlePlugin =
+        "org.jetbrains.kotlin:kotlin-gradle-plugin:${DependencyVersions.kotlinGradlePlugin}"
+    const val hiltGradlePlugin =
+        "com.google.dagger:hilt-android-gradle-plugin:${DependencyVersions.daggerHilt}"
 }

--- a/buildSrc/src/main/java/DependencyHandlerExtensions.kt
+++ b/buildSrc/src/main/java/DependencyHandlerExtensions.kt
@@ -59,6 +59,13 @@ fun DependencyHandlerScope.apolloClientLibraries() {
 }
 
 /**
+ * Add log dependencies.
+ */
+fun DependencyHandlerScope.logLibraries() {
+    implementation(Dependencies.Log.timber)
+}
+
+/**
  * Add unit tests dependencies.
  */
 fun DependencyHandlerScope.unitTestsLibraries() {


### PR DESCRIPTION
Esse PR adiciona o Timber ao projeto, como dependência para criar logs.  O timber foi escolhido por tem compatibilidade com a biblioteca do okHttp, que será usada no ApolloClient.

### Solução
- Adicionado o Timber ao projeto
- Criada a classe LogHandler to create a wrapper over the log library
- Adicionado teste para o LogHandler