### PR TITLE
Injeção de dependência para Apollo e ViewModels

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     jetpackComposeLibraries()
 
     // Add dependency injection dependencies
-    daggerHiltLibraries()
+    hiltLibraries()
 
     // Add networking libraries
     apolloClientLibraries()

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/HomeModule.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/HomeModule.kt
@@ -1,0 +1,23 @@
+package com.github.felipecastilhos.pokedexandroid
+
+import com.apollographql.apollo.ApolloClient
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/**
+ * This module creates all components used in the Home feature
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+class HomeModule {
+    /**
+     * Provides the [PokemonUseCase] component
+     * @param apolloClient to performs the query into pokemon-graphql api
+     */
+    @Provides
+    fun providesPokemonUseCase(apolloClient: ApolloClient?): PokemonUseCase {
+        return PokemonUseCase(apolloClient)
+    }
+}

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/MainActivity.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/MainActivity.kt
@@ -3,6 +3,7 @@ package com.github.felipecastilhos.pokedexandroid
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -10,19 +11,23 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.github.felipecastilhos.pokedexandroid.logs.LogHandler
 import com.github.felipecastilhos.pokedexandroid.ui.theme.PokedexandroidTheme
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    private val pokedexHomeViewModel = PokedexHomeViewModel(PokemonUseCase())
+    private val pokedexHomeViewModel: PokedexHomeViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        pokedexHomeViewModel
         CoroutineScope(Dispatchers.IO).launch {
             val e = pokedexHomeViewModel.searchPokemon()
-            LogHandler.d("This is a Dragonite. Pokemon Nbr.: ${e?.getPokemon?.num}")
+            e?.let {
+                LogHandler.d("This is a Dragonite. Pokemon Nbr.: ${e.getPokemon.num}")
+            }
         }
 
         setContent {

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/PokedexHomeViewModel.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/PokedexHomeViewModel.kt
@@ -1,8 +1,12 @@
 package com.github.felipecastilhos.pokedexandroid
 
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class PokedexHomeViewModel(private val pokemonUseCase: PokemonUseCase) : ViewModel() {
+@HiltViewModel
+class PokedexHomeViewModel @Inject constructor(private val pokemonUseCase: PokemonUseCase) :
+    ViewModel() {
     suspend fun searchPokemon(): GetPokemonQuery.Data? {
         return pokemonUseCase.search()
     }

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/PokemonUseCase.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/PokemonUseCase.kt
@@ -1,10 +1,11 @@
 package com.github.felipecastilhos.pokedexandroid
 
+import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.coroutines.await
+import javax.inject.Inject
 
-class PokemonUseCase {
+class PokemonUseCase @Inject constructor(private val apolloClient: ApolloClient?) {
     suspend fun search(): GetPokemonQuery.Data? {
-        val apolloClient = PokedexApolloClient.build()
         return apolloClient?.query(GetPokemonQuery())?.await()?.data
     }
 }

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/network/NetworkModule.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/network/NetworkModule.kt
@@ -1,0 +1,47 @@
+package com.github.felipecastilhos.pokedexandroid.network
+
+import com.apollographql.apollo.ApolloClient
+import com.github.felipecastilhos.pokedexandroid.Enviroment
+import com.github.felipecastilhos.pokedexandroid.PokedexApolloClient
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import javax.inject.Singleton
+
+/**
+ * This module is responsible to create all network components used in the application
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+class NetworkModule {
+    /**
+     * Provides the api url
+     */
+    @Provides
+    fun providePokedexApiUrl() = Enviroment.Production.graphQlUrl
+
+    /**
+     * Provides the OkHttpClient setup
+     */
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(PokedexApolloClient.buildLogInterceptor(HttpLoggingInterceptor.Level.BODY))
+        .build()
+
+    /**
+     * Provides an ApolloClient setup
+     * @param okHttpClient to create the network communication
+     * @param apiUrl to query
+     */
+    @Provides
+    @Singleton
+    fun provideApolloClient(okHttpClient: OkHttpClient, apiUrl: String): ApolloClient =
+        ApolloClient.builder()
+            .serverUrl(apiUrl)
+            .okHttpClient(okHttpClient)
+            .build()
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -12,6 +12,7 @@ object DependencyVersions {
     const val androidxComposeJunit = "1.0.5"
     const val kotlinCompilerExtension = "1.0.1"
     const val daggerHilt = "2.37"
+    const val jetpackHilt = "1.0.0-alpha01"
 
     const val buildGradle = "7.0.3"
     const val kotlinGradlePlugin = "1.5.21"
@@ -29,6 +30,8 @@ sealed class Dependencies {
         const val daggerHilt = "com.google.dagger:hilt-android:${DependencyVersions.daggerHilt}"
         const val daggerHiltCompiler =
             "com.google.dagger:hilt-android-compiler:${DependencyVersions.daggerHilt}"
+        const val jetpackHiltLifecycleViewModel = "androidx.hilt:hilt-lifecycle-viewmodel:${DependencyVersions.jetpackHilt}"
+        const val jetpackHiltCompiler = "androidx.hilt:hilt-compiler:${DependencyVersions.jetpackHilt}"
     }
 
     object AndroidLifecycle {

--- a/buildSrc/src/main/java/DependencyHandlerExtensions.kt
+++ b/buildSrc/src/main/java/DependencyHandlerExtensions.kt
@@ -43,11 +43,13 @@ fun DependencyHandlerScope.jetpackAndroidLifecycleLibraries() {
 }
 
 /**
- * Add Dagger-Hilt dependencies for dependency injection
+ * Add hilt dependencies for dependency injection
  */
-fun DependencyHandlerScope.daggerHiltLibraries() {
+fun DependencyHandlerScope.hiltLibraries() {
     implementation(Dependencies.DependencyInjection.daggerHilt)
     kapt(Dependencies.DependencyInjection.daggerHiltCompiler)
+    implementation(Dependencies.DependencyInjection.jetpackHiltLifecycleViewModel)
+    kapt(Dependencies.DependencyInjection.jetpackHiltCompiler)
 }
 
 /**


### PR DESCRIPTION
### Descrição
- Configuração necessária para que o Apollo client possa ser fornecido através de injeção de pendências.
- Configuração necessária para que uma ViewModel possa ser injetada em uma activity.
 
### Solução
- Adicionada biblioteca do Jetpack Hilt para injeção de viewmodels
- Adicionada biblioteca do Jetpack para complicação das classes de injeção de dependência de view model
- Criado NetworkModule, para injeção de depedendência do Apollo e do OkHttp
- Criado PokedexHomeModule, para injeção de dependência da feature Home

### Próximos Passos
- Criar uma camada de networking, para lidar com loading e erros