### PR TITLE
Adicionando biblioteca para mockar objetos em testes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Libraries Used
 * [Espresso](https://developer.android.com/training/testing/espresso/) - UI test
 * [Junit](https://junit.org/junit4/) - unit tests
 * [Truth](https://github.com/google/truth) - Makes your test assertions and failure messages more readable
+* [Mockk](https://mockk.io/) - Mocking library for kotlin
 * [Detekt](https://github.com/detekt/detekt) - a static code analysis tool for the Kotlin programming language
 * [KTLint](https://github.com/pinterest/ktlint) - Kotlin linter in spirit of feross/standard (JavaScript) and gofmt (Go).
 * [Gradle Kotlin Plugin](https://kotlinlang.org/docs/gradle.html) - Gradle scripts in Kotlin

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,7 +62,7 @@ android {
 
 dependencies {
     // Common libraries
-    jetpackUtilLibraries()
+    jetpackCoreLibraries()
     jetpackKotlinExtensionsLibraries()
     jetpackAndroidLifecycleLibraries()
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,4 +83,5 @@ dependencies {
     // Add Tests
     unitTestsLibraries()
     instrumentationTestsLibraries()
+    mockLibraries()
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,7 +1,9 @@
+/**
+ * All dependency versions used
+ */
 object DependencyVersions {
     const val androidxCore = "1.7.0"
     const val androidxAppCompat = "1.3.1"
-
     const val composeVersion = "1.0.5"
     const val androidxLifecycle = "2.4.0"
     const val androidMaterial = "1.4.0"
@@ -13,19 +15,18 @@ object DependencyVersions {
     const val kotlinCompilerExtension = "1.0.1"
     const val daggerHilt = "2.37"
     const val jetpackHilt = "1.0.0-alpha01"
-
     const val buildGradle = "7.0.3"
     const val kotlinGradlePlugin = "1.5.21"
     const val apolloVersion = "2.5.11"
     const val okHttpVersion = "4.9.2"
     const val timber = "5.0.1"
+    const val mockk = "1.12.1"
 }
 
+/**
+ * List of dependencies added in the project by context
+ */
 sealed class Dependencies {
-    object Core {
-        const val androidxCore = "androidx.core:core-ktx:${DependencyVersions.androidxCore}"
-    }
-
     object DependencyInjection {
         const val daggerHilt = "com.google.dagger:hilt-android:${DependencyVersions.daggerHilt}"
         const val daggerHiltCompiler =
@@ -48,6 +49,7 @@ sealed class Dependencies {
     }
 
     object JetpackCompose {
+        const val androidxCore = "androidx.core:core-ktx:${DependencyVersions.androidxCore}"
         const val ui = "androidx.compose.ui:ui:${DependencyVersions.composeVersion}"
         const val material =
             "androidx.compose.material:material:${DependencyVersions.composeVersion}"
@@ -66,6 +68,7 @@ sealed class Dependencies {
             "androidx.test.espresso:espresso-core:${DependencyVersions.androidxEspresso}"
         const val composejUnit =
             "androidx.compose.ui:ui-test-junit4:${DependencyVersions.androidxComposeJunit}"
+        const val mockk: String = "io.mockk:mockk:${DependencyVersions.mockk}"
     }
 
     object Network {

--- a/buildSrc/src/main/java/DependencyHandlerExtensions.kt
+++ b/buildSrc/src/main/java/DependencyHandlerExtensions.kt
@@ -3,8 +3,8 @@ import org.gradle.kotlin.dsl.DependencyHandlerScope
 /**
  * Add AndroidX dependencies
  */
-fun DependencyHandlerScope.jetpackUtilLibraries() {
-    implementation(Dependencies.Core.androidxCore)
+fun DependencyHandlerScope.jetpackCoreLibraries() {
+    implementation(Dependencies.JetpackCompose.androidxCore)
 }
 
 /**
@@ -79,6 +79,10 @@ fun DependencyHandlerScope.unitTestsLibraries() {
     testImplementation(Dependencies.Tests.jUnit)
 }
 
+fun DependencyHandlerScope.mockLibraries() {
+    testImplementation(Dependencies.Tests.mockk)
+}
+
 /**
  * Add unit tests dependencies.
  */
@@ -88,22 +92,37 @@ fun DependencyHandlerScope.instrumentationTestsLibraries() {
     androidTestImplementation(Dependencies.Tests.composejUnit)
 }
 
+/**
+ * Extension add library operator in Kotlin Gradle SDL
+ */
 fun DependencyHandlerScope.implementation(dependencyNotation: String) {
     "implementation"(dependencyNotation)
 }
 
+/**
+ * Extension to add library for instrumented tests only in Kotlin Gradle SDL
+ */
 fun DependencyHandlerScope.testImplementation(dependencyNotation: String) {
     "testImplementation"(dependencyNotation)
 }
 
+/**
+ * Extension to add library for testing only in Kotlin Gradle SDL
+ */
 fun DependencyHandlerScope.androidTestImplementation(dependencyNotation: String) {
     "androidTestImplementation"(dependencyNotation)
 }
 
+/**
+ * Extension to add library to the build in Kotlin Gradle SDL
+ */
 fun DependencyHandlerScope.kapt(dependencyNotation: String) {
     "kapt"(dependencyNotation)
 }
 
+/**
+ * Extension to call debugImplementation operator in Kotlin Gradle SDL
+ */
 fun DependencyHandlerScope.debugImplementation(dependencyNotation: String) {
     "debugImplementation"(dependencyNotation)
 }


### PR DESCRIPTION
### Descrição
Biblioteca adicionada para que seja possível mockar objetos como o Apollo.

### Solução
- Adicionada versão e biblioteca ao arquivo  `Dependencies.kt`
- Adicionado biblioteca no `build.gradle`

### Próximos passos
- Adicionar teste de viewmodel