### PR TITLE
Utilizando abstração de modelos de dominio

### DIFF
--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/HomeActivity.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/HomeActivity.kt
@@ -4,14 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.tooling.preview.Preview
-import com.github.felipecastilhos.pokedexandroid.GetPokemonQuery
 import com.github.felipecastilhos.pokedexandroid.core.datasource.Resource
 import com.github.felipecastilhos.pokedexandroid.core.ui.theme.PokedexandroidTheme
 import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.Pokemon
@@ -38,10 +37,7 @@ class HomeActivity : ComponentActivity() {
                             Text("Ops, algo deu errado :(")
                         }
                         is Resource.Success -> {
-                            SearchPokemonResult(
-                                pokemonName = "Dragonite",
-                                pokemonNumber = (e as Resource.Success<Pokemon?>).data?.pokedexNumber
-                            )
+                            (e as Resource.Success<Pokemon?>).data?.let { SearchPokemonResult(it) }
                         }
                     }
                 }
@@ -52,21 +48,13 @@ class HomeActivity : ComponentActivity() {
 
 @Composable
 fun SearchPokemonResult(
-    pokemonName: String,
-    pokemonNumber: Int?
+    pokemon: Pokemon
 ) {
-    Text(text = "This is a $pokemonName. Pokemon Nbr.: ${pokemonNumber ?: "not found"}")
-}
-
-@Composable
-fun Greeting(name: String) {
-    Text(text = "Hello $name!")
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    PokedexandroidTheme {
-        Greeting("Android")
+    Column {
+        Text("Pokemon Specie: ${pokemon.species}.")
+        Text("Number: ${pokemon.pokedexNumber}")
+        Text("Height: ${pokemon.height} ft")
+        Text("Weight: ${pokemon.weight} lbs")
+        Text("Info: ${pokemon.flavorText.first().flavor}")
     }
 }

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/HomeActivity.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/HomeActivity.kt
@@ -15,6 +15,7 @@ import com.github.felipecastilhos.pokedexandroid.GetPokemonQuery
 import com.github.felipecastilhos.pokedexandroid.core.datasource.Resource
 import com.github.felipecastilhos.pokedexandroid.core.datasource.onError
 import com.github.felipecastilhos.pokedexandroid.core.ui.theme.PokedexandroidTheme
+import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.Pokemon
 import com.github.felipecastilhos.pokedexandroid.features.home.domain.viewmodel.PokedexHomeViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -40,7 +41,7 @@ class HomeActivity : ComponentActivity() {
                         is Resource.Success -> {
                             SearchPokemonResult(
                                 pokemonName = "Dragonite",
-                                pokemonNumber = (e as Resource.Success<GetPokemonQuery.GetPokemon?>).data?.num
+                                pokemonNumber = (e as Resource.Success<Pokemon?>).data?.pokedexNumber
                             )
                         }
                     }

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/di/HomeModule.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/di/HomeModule.kt
@@ -3,7 +3,7 @@ package com.github.felipecastilhos.pokedexandroid.features.home.di
 import com.apollographql.apollo.ApolloClient
 import com.github.felipecastilhos.pokedexandroid.features.home.data.datasource.HomeRemoteDataSource
 import com.github.felipecastilhos.pokedexandroid.features.home.data.datasource.HomeRemoteGraphQlDataSourceExecutor
-import com.github.felipecastilhos.pokedexandroid.features.home.domain.repository.PokemonRemoteDataRepositoryImpl
+import com.github.felipecastilhos.pokedexandroid.features.home.domain.repository.PokemonRemoteDataRepositoryExecutor
 import com.github.felipecastilhos.pokedexandroid.features.home.domain.repository.PokemonRepository
 import com.github.felipecastilhos.pokedexandroid.features.home.domain.usecase.PokemonUseCase
 import dagger.Module
@@ -33,7 +33,7 @@ class HomeModule {
      */
     @Provides
     fun providesPokemonRepository(homeRemoteGraphQlDataSourceExecutor: HomeRemoteGraphQlDataSourceExecutor): PokemonRepository {
-        return PokemonRemoteDataRepositoryImpl(homeRemoteGraphQlDataSourceExecutor)
+        return PokemonRemoteDataRepositoryExecutor(homeRemoteGraphQlDataSourceExecutor)
     }
 
     /**
@@ -41,7 +41,7 @@ class HomeModule {
      * @param pokemonRemoteDataRepository contains all pokemon related data
      */
     @Provides
-    fun providesPokemonUseCase(pokemonRemoteDataRepository: PokemonRemoteDataRepositoryImpl): PokemonUseCase {
+    fun providesPokemonUseCase(pokemonRemoteDataRepository: PokemonRemoteDataRepositoryExecutor): PokemonUseCase {
         return PokemonUseCase(pokemonRemoteDataRepository)
     }
 }

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/di/HomeModule.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/di/HomeModule.kt
@@ -21,7 +21,7 @@ class HomeModule {
      * Provides a remote data source for home data
      */
     @Provides
-    fun providesHomeRemoteDataSource(
+    fun providesHomeRemoteDataSourceExecutor(
         apolloClient: ApolloClient
     ): HomeRemoteDataSource {
         return HomeRemoteGraphQlDataSourceExecutor(apolloClient)

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/models/PokemonModels.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/models/PokemonModels.kt
@@ -1,0 +1,34 @@
+package com.github.felipecastilhos.pokedexandroid.features.home.domain.models
+
+data class Pokemon(
+    val pokedexNumber: Int,
+    val species: String,
+    val types: List<PokemonTypes?>,
+    val height: Double,
+    val weight: Double,
+    val flavorText: List<FlavorText>
+)
+
+data class FlavorText(val game: String, val flavor: String)
+
+enum class PokemonTypes {
+    Normal,
+    Fighting,
+    Flying,
+    Poison,
+    Ground,
+    Rock,
+    Bug,
+    Ghost,
+    Steel,
+    Fire,
+    Water,
+    Glass,
+    Eletric,
+    Psychic,
+    Ice,
+    Dragon,
+    Dark,
+    Fairy,
+    Unknown
+}

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/DomainModelMappers.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/DomainModelMappers.kt
@@ -6,6 +6,9 @@ import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.Fla
 import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.Pokemon
 import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.PokemonTypes
 
+/**
+ * Maps [GetPokemonQuery.GetPokemon] to [Pokemon] domain model
+ */
 fun GetPokemonQuery.GetPokemon.mapToDomainModel(): Pokemon = Pokemon(
     pokedexNumber = this.num,
     species = this.species,
@@ -15,17 +18,29 @@ fun GetPokemonQuery.GetPokemon.mapToDomainModel(): Pokemon = Pokemon(
     flavorText = this.flavorTexts.toFlavorListDomainModel()
 )
 
+/**
+ * Maps [GetPokemonQuery.FlavorText] list to [FlavorText] domain model list
+ */
 fun List<GetPokemonQuery.FlavorText>.toFlavorListDomainModel(): List<FlavorText> = map {
     it.toFlavorListDomainModel()
 }
 
+/**
+ * Maps [GetPokemonQuery.FlavorText] to [FlavorText] domain model
+ */
 fun GetPokemonQuery.FlavorText.toFlavorListDomainModel(): FlavorText =
     FlavorText(game = game, flavor = flavor)
 
+/**
+ * Maps List<String> to list of [PokemonTypes] domain model
+ */
 fun List<String>.toTypesDomainModel(): List<PokemonTypes?> = map {
     it.mapToTypesDomainModel()
 }
 
+/**
+ * Maps List<String> to [PokemonTypes] domain model
+ */
 fun String.mapToTypesDomainModel(): PokemonTypes? =
     try {
         PokemonTypes.valueOf(this)

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/DomainModelMappers.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/DomainModelMappers.kt
@@ -1,0 +1,35 @@
+package com.github.felipecastilhos.pokedexandroid.features.home.domain.repository
+
+import com.github.felipecastilhos.pokedexandroid.GetPokemonQuery
+import com.github.felipecastilhos.pokedexandroid.core.logs.LogHandler
+import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.FlavorText
+import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.Pokemon
+import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.PokemonTypes
+
+fun GetPokemonQuery.GetPokemon.mapToDomainModel(): Pokemon = Pokemon(
+    pokedexNumber = this.num,
+    species = this.species,
+    types = this.types.toTypesDomainModel(),
+    height = this.height,
+    weight = this.weight,
+    flavorText = this.flavorTexts.toFlavorListDomainModel()
+)
+
+fun List<GetPokemonQuery.FlavorText>.toFlavorListDomainModel(): List<FlavorText> = map {
+    it.toFlavorListDomainModel()
+}
+
+fun GetPokemonQuery.FlavorText.toFlavorListDomainModel(): FlavorText =
+    FlavorText(game = game, flavor = flavor)
+
+fun List<String>.toTypesDomainModel(): List<PokemonTypes?> = map {
+    it.mapToTypesDomainModel()
+}
+
+fun String.mapToTypesDomainModel(): PokemonTypes? =
+    try {
+        PokemonTypes.valueOf(this)
+    } catch (e: IllegalArgumentException) {
+        LogHandler.d("Não foi converter para modelo de domínio")
+        null
+    }

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/PokemonRepository.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/PokemonRepository.kt
@@ -2,11 +2,8 @@ package com.github.felipecastilhos.pokedexandroid.features.home.domain.repositor
 
 import com.github.felipecastilhos.pokedexandroid.GetPokemonQuery
 import com.github.felipecastilhos.pokedexandroid.core.datasource.Resource
-import com.github.felipecastilhos.pokedexandroid.core.logs.LogHandler
 import com.github.felipecastilhos.pokedexandroid.features.home.data.datasource.HomeRemoteDataSource
-import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.FlavorText
 import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.Pokemon
-import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.PokemonTypes
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -45,31 +42,3 @@ fun Flow<Resource<GetPokemonQuery.GetPokemon?>>.mapToDomainFlow(): Flow<Resource
         }
     }
 }
-
-fun GetPokemonQuery.GetPokemon.mapToDomainModel(): Pokemon = Pokemon(
-    pokedexNumber = this.num,
-    species = this.species,
-    types = this.types.toTypesDomainModel(),
-    height = this.height,
-    weight = this.weight,
-    flavorText = this.flavorTexts.toFlavorListDomainModel()
-)
-
-fun List<GetPokemonQuery.FlavorText>.toFlavorListDomainModel(): List<FlavorText> = map {
-    it.toFlavorListDomainModel()
-}
-
-fun GetPokemonQuery.FlavorText.toFlavorListDomainModel(): FlavorText =
-    FlavorText(game = game, flavor = flavor)
-
-fun List<String>.toTypesDomainModel(): List<PokemonTypes?> = map {
-    it.mapToTypesDomainModel()
-}
-
-fun String.mapToTypesDomainModel(): PokemonTypes? =
-    try {
-        PokemonTypes.valueOf(this)
-    } catch (e: IllegalArgumentException) {
-        LogHandler.d("Não foi converter para modelo de domínio")
-        null
-    }

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/PokemonRepository.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/PokemonRepository.kt
@@ -33,6 +33,9 @@ class PokemonRemoteDataRepositoryExecutor @Inject constructor(
         homeRemoteDataSource.search().mapToDomainFlow()
 }
 
+/**
+ * Map Apollo Client GraphQl Result to domain abstraction flow
+ */
 fun Flow<Resource<GetPokemonQuery.GetPokemon?>>.mapToDomainFlow(): Flow<Resource<Pokemon?>> {
     return map {
         when (it) {

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/PokemonRepository.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/PokemonRepository.kt
@@ -20,7 +20,7 @@ interface PokemonRepository {
  * Remote pokemon data repository
  * @param homeRemoteDataSource for query pokemon data
  */
-class PokemonRemoteDataRepositoryImpl @Inject constructor(
+class PokemonRemoteDataRepositoryExecutor @Inject constructor(
     private val homeRemoteDataSource: HomeRemoteDataSource
 ) :
     PokemonRepository {

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/PokemonRepository.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/repository/PokemonRepository.kt
@@ -2,8 +2,13 @@ package com.github.felipecastilhos.pokedexandroid.features.home.domain.repositor
 
 import com.github.felipecastilhos.pokedexandroid.GetPokemonQuery
 import com.github.felipecastilhos.pokedexandroid.core.datasource.Resource
+import com.github.felipecastilhos.pokedexandroid.core.logs.LogHandler
 import com.github.felipecastilhos.pokedexandroid.features.home.data.datasource.HomeRemoteDataSource
+import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.FlavorText
+import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.Pokemon
+import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.PokemonTypes
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 /**
@@ -13,7 +18,7 @@ interface PokemonRepository {
     /**
      * Query for all data of a single pokemon
      */
-    suspend fun search(): Flow<Resource<GetPokemonQuery.GetPokemon?>>
+    suspend fun search(): Flow<Resource<Pokemon?>>
 }
 
 /**
@@ -27,6 +32,44 @@ class PokemonRemoteDataRepositoryExecutor @Inject constructor(
     /**
      * Query for all data of a single pokemon
      */
-    override suspend fun search(): Flow<Resource<GetPokemonQuery.GetPokemon?>> =
-        homeRemoteDataSource.search()
+    override suspend fun search(): Flow<Resource<Pokemon?>> =
+        homeRemoteDataSource.search().mapToDomainFlow()
 }
+
+fun Flow<Resource<GetPokemonQuery.GetPokemon?>>.mapToDomainFlow(): Flow<Resource<Pokemon?>> {
+    return map {
+        when (it) {
+            is Resource.Error -> it
+            Resource.Loading -> Resource.Loading
+            is Resource.Success -> Resource.Success(it.data?.mapToDomainModel())
+        }
+    }
+}
+
+fun GetPokemonQuery.GetPokemon.mapToDomainModel(): Pokemon = Pokemon(
+    pokedexNumber = this.num,
+    species = this.species,
+    types = this.types.toTypesDomainModel(),
+    height = this.height,
+    weight = this.weight,
+    flavorText = this.flavorTexts.toFlavorListDomainModel()
+)
+
+fun List<GetPokemonQuery.FlavorText>.toFlavorListDomainModel(): List<FlavorText> = map {
+    it.toFlavorListDomainModel()
+}
+
+fun GetPokemonQuery.FlavorText.toFlavorListDomainModel(): FlavorText =
+    FlavorText(game = game, flavor = flavor)
+
+fun List<String>.toTypesDomainModel(): List<PokemonTypes?> = map {
+    it.mapToTypesDomainModel()
+}
+
+fun String.mapToTypesDomainModel(): PokemonTypes? =
+    try {
+        PokemonTypes.valueOf(this)
+    } catch (e: IllegalArgumentException) {
+        LogHandler.d("Não foi converter para modelo de domínio")
+        null
+    }

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/usecase/PokemonUseCase.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/usecase/PokemonUseCase.kt
@@ -1,7 +1,7 @@
 package com.github.felipecastilhos.pokedexandroid.features.home.domain.usecase
 
-import com.github.felipecastilhos.pokedexandroid.GetPokemonQuery
 import com.github.felipecastilhos.pokedexandroid.core.datasource.Resource
+import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.Pokemon
 import com.github.felipecastilhos.pokedexandroid.features.home.domain.repository.PokemonRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -15,7 +15,7 @@ class PokemonUseCase @Inject constructor(
     /**
      * Retrieve all pokemon data
      */
-    suspend fun search(): Flow<Resource<GetPokemonQuery.GetPokemon?>> {
+    suspend fun search(): Flow<Resource<Pokemon?>> {
         return pokemonRepository.search()
     }
 }

--- a/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/viewmodel/PokedexHomeViewModel.kt
+++ b/app/src/main/java/com/github/felipecastilhos/pokedexandroid/features/home/domain/viewmodel/PokedexHomeViewModel.kt
@@ -1,18 +1,14 @@
 package com.github.felipecastilhos.pokedexandroid.features.home.domain.viewmodel
 
 import androidx.lifecycle.viewModelScope
-import com.github.felipecastilhos.pokedexandroid.GetPokemonQuery
 import com.github.felipecastilhos.pokedexandroid.core.coroutines.DispatcherProvider
 import com.github.felipecastilhos.pokedexandroid.core.datasource.Resource
 import com.github.felipecastilhos.pokedexandroid.core.logs.LogHandler
 import com.github.felipecastilhos.pokedexandroid.core.viewmodels.CoroutineViewModel
+import com.github.felipecastilhos.pokedexandroid.features.home.domain.models.Pokemon
 import com.github.felipecastilhos.pokedexandroid.features.home.domain.usecase.PokemonUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -27,19 +23,19 @@ class PokedexHomeViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider
 ) :
     CoroutineViewModel(dispatcherProvider) {
-    protected val _stateFlow: MutableStateFlow<Resource<GetPokemonQuery.GetPokemon?>> by lazy {
-        MutableStateFlow<Resource<GetPokemonQuery.GetPokemon?>>(Resource.Loading).apply {
+    protected val _stateFlow: MutableStateFlow<Resource<Pokemon?>> by lazy {
+        MutableStateFlow<Resource<Pokemon?>>(Resource.Loading).apply {
             launchInIoScope {
                 searchPokemon()
             }
         }
     }
-    val stateFlow: StateFlow<Resource<GetPokemonQuery.GetPokemon?>> by lazy { _stateFlow.asStateFlow() }
+    val stateFlow: StateFlow<Resource<Pokemon?>> by lazy { _stateFlow.asStateFlow() }
 
     /**
      * Query pokemon data
      */
-    suspend fun searchPokemon(): Flow<Resource<GetPokemonQuery.GetPokemon?>> {
+    suspend fun searchPokemon(): Flow<Resource<Pokemon?>> {
         viewModelScope.launch {
             LogHandler.d("Searching Dragonite")
             pokemonUseCase.search().collect {

--- a/buildSrc/src/main/java/BuildConfigVersions.kt
+++ b/buildSrc/src/main/java/BuildConfigVersions.kt
@@ -3,5 +3,5 @@ object BuildConfigVersions {
     const val minSdk = 23
     const val targetSdk = 31
     const val versionCode = 1
-    const val versionName = "0.0.7"
+    const val versionName = "0.0.8"
 }


### PR DESCRIPTION
### Descrição
Para isolar as classes de graphql na camada de datasource, o repositório vai ficar com a responsabilidade de transformar as classes de datasource em classes de dominio para dentro da aplicação.

Aqui futuramente seria interessante tratar melhor os erros do graphql

### Solução
- Adicionado mappers na camada dos repositories para converter objetos do graphql em modelos do repositório

### Próximos passos
- Adicionar testes nas viewmodels, repositories e use cases

